### PR TITLE
Drop 7.2 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       # Keys:
       # - experimental: Whether the build is "allowed to fail".
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['7.3', '7.4', '8.0', '8.1']
         experimental: [false]
 
         # Add new PHP versions that are not fully supported yet here.


### PR DESCRIPTION
As UnitTest now requires phpunit 9